### PR TITLE
[Fix] #58 - 유저 정보 JWT aud 클레임에 providerId 값이 들어가버림 > userId로 수정

### DIFF
--- a/src/main/java/org/unilab/improfessorbe/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/unilab/improfessorbe/domain/user/service/CustomOAuth2UserService.java
@@ -42,7 +42,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 		User user = processOAuth2User(userInfo);
 
-		return new CustomOAuth2User(oAuth2User, user.getEmail(), registrationId, userNameAttributeName);
+		return new CustomOAuth2User(oAuth2User, user.getUserId(), user.getEmail(),
+			registrationId, userNameAttributeName);
 	}
 
 	private User processOAuth2User(OAuth2UserInfo userInfo) {

--- a/src/main/java/org/unilab/improfessorbe/global/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/org/unilab/improfessorbe/global/security/oauth2/CustomOAuth2User.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CustomOAuth2User implements OAuth2User {
 	private OAuth2User oauth2User;
+	private Long userId;
 	private String email;
 	private String provider;
 	private String userNameAttributeName;
@@ -29,6 +30,6 @@ public class CustomOAuth2User implements OAuth2User {
 
 	@Override
 	public String getName() {
-		return oauth2User.getAttribute(userNameAttributeName).toString();
+		return String.valueOf(userId);
 	}
 }

--- a/src/main/java/org/unilab/improfessorbe/global/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/unilab/improfessorbe/global/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -38,7 +38,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
 			// Refresh Token을 Redis에 저장
 			long refreshTokenExpirationMillis = 604800000L; // 7일
-			redisUtil.setDataExpire(oAuth2User.getEmail(), jwtToken.getRefreshToken(),
+			redisUtil.setDataExpire(oAuth2User.getName(), jwtToken.getRefreshToken(),
 				refreshTokenExpirationMillis / 1000);
 
 			// 프론트엔드로 리다이렉트 (토큰을 쿼리 파라미터로 전달)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: prod
   datasource:
     url: ${MYSQL_URL}
     username: ${MYSQL_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: local
   datasource:
     url: ${MYSQL_URL}
     username: ${MYSQL_USERNAME}


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
#58 

## 개요
<!-- 어떤 이슈를 해결하거나 어떤 기능을 추가했는지 간략히 작성 -->
유저 정보 JWT aud 클레임에 providerId 값이 들어가버림 > 프론ㄴ트에서 providerId값을 넘겨주고 이걸로 userId에 맞는 유저 찾으려해서 오류 발생.

## 작업 내용
<!-- 실제로 작업한 내용 리스트 -->
-  JWT aud 클레임에 userId 값 넣음
-  Refresh 토큰에도 userId 키 값으로 넣음

##  기타
<!-- 리뷰어가 참고하면 좋을 사항 -->
