### PR TITLE
[Feature] #74 - Production Front URI 맞게 환경 설정 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:17
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENV TZ=Asia/Seoul
-ENTRYPOINT ["java", "-jar","-Dspring.profiles.active=prod", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/manifests/prod/config.yaml
+++ b/manifests/prod/config.yaml
@@ -21,4 +21,4 @@ data:
 
   # OAuth2 리다이렉트 URI
   KAKAO_REDIRECT_URI: "https://prod.improfessor.kro.kr/login/oauth2/code/kakao"
-  AUTHORIZED_REDIRECT_URI: "https://improfessor.vercel.app/generate"
+  AUTHORIZED_REDIRECT_URI: "https://impro-1.vercel.app/generate"

--- a/src/main/java/org/unilab/improfessorbe/global/config/SecurityConfig.java
+++ b/src/main/java/org/unilab/improfessorbe/global/config/SecurityConfig.java
@@ -92,8 +92,8 @@ public class SecurityConfig {
 		corsConfiguration.setAllowedMethods(Collections.singletonList("*"));
 		corsConfiguration.setAllowCredentials(true);
 		corsConfiguration.setAllowedOrigins(
-			List.of("http://localhost:5173", "https://www.improfessor.co.kr", "https://api.improfessor.kro.kr",
-				"https://improfessor.vercel.app/")
+			List.of("http://localhost:5173", "https://www.improfessor.co.kr", "https://impro-1.vercel.app",
+				"https://improfessor.vercel.app")
 		);
 
 		corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"));


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
#74 

## 개요
<!-- 어떤 이슈를 해결하거나 어떤 기능을 추가했는지 간략히 작성 -->
프론트엔드 Production 도메인 추가에 따른 백엔드 설정 수정 및 배포 환경 최적화

## 작업 내용
<!-- 실제로 작업한 내용 리스트 -->
- Dockerfile에서 하드코딩된 Spring Profile 설정 제거 (`-Dspring.profiles.active=prod`)
- ConfigMap에서 AUTHORIZED_REDIRECT_URI를 `https://impro-1.vercel.app/generate`로 변경
- CORS 설정을 새로운 프론트엔드 도메인에 맞게 업데이트
- Kubernetes Ingress 설정에서 prod.improfessor.kro.kr이 올바른 backend-prod-service로 라우팅되도록 수정
- 환경변수 기반 설정이 올바르게 적용되도록 배포 구성 개선

##  기타
<!-- 리뷰어가 참고하면 좋을 사항 -->
- 이제 모든 환경별 설정이 Kubernetes ConfigMap/Secret을 통해 관리됩니다
- Docker 이미지는 환경에 중립적이 되어 재사용성이 향상되었습니다
- 카카오 로그인 후 리다이렉트가 올바른 프론트엔드 도메인으로 이루어집니다
- 배포 후 카카오 로그인 플로우 전체를 테스트해주세요