### PR TITLE
[Feature] #82 - manifest 설정 파일 수정

### DIFF
--- a/manifests/prod/deployment.yaml
+++ b/manifests/prod/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: "8080"
             - name: ENVIRONMENT
               value: "production"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms512m -Xmx768m -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC"
 
           # 리소스 제한 (노드 리소스 고려한 안전한 설정)
           resources:

--- a/manifests/test/deployment.yaml
+++ b/manifests/test/deployment.yaml
@@ -45,7 +45,10 @@ spec:
               value: "8080"
             - name: ENVIRONMENT
               value: "test"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms512m -Xmx768m -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+UseG1GC"
 
+          
           resources:
             requests:
               memory: "512Mi"


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
#82 

## 개요
<!-- 어떤 이슈를 해결하거나 어떤 기능을 추가했는지 간략히 작성 -->
Kubernetes 환경에서 JVM 메모리 최적화 및 G1 GC 적용으로 OOM 위험 제거

## 작업 내용
<!-- 실제로 작업한 내용 리스트 -->
- JVM 힙 메모리 명시적 설정 추가 (Xms512m, Xmx768m)
- G1 GC 알고리즘 적용으로 대용량 힙 메모리 환경 최적화
- UseContainerSupport 옵션으로 Kubernetes 컨테이너 환경 인식 활성화
- MaxRAMPercentage 75%로 설정하여 컨테이너 메모리의 적절한 비율 사용
- 테스트 환경 및 운영 환경 Deployment에 JAVA_TOOL_OPTIONS 환경변수 추가

##  기타
<!-- 리뷰어가 참고하면 좋을 사항 -->
**변경 전 메모리 상태:**
- Old Generation 99% 사용 (86MB 중 86MB)
- OOM 발생 위험 높음
- Serial GC 사용으로 긴 정지 시간

**변경 후 메모리 상태:**
- Heap 43.6% 사용 (512MB 중 223MB)
- 289MB 여유 공간 확보
- G1 GC로 예측 가능한 정지 시간 보장

**주요 개선사항:**
- 힙 크기: 86MB → 512MB (약 6배 증가)
- 메모리 사용률: 99% → 43.6% (안전 수준)
- GC 알고리즘: Serial GC → G1 GC (성능 향상)

**설정 근거:**
- Kubernetes limits(1Gi)의 75%(768MB)를 JVM 최대 힙으로 설정
- 나머지 25%는 Metaspace, Native Memory, 버퍼용으로 확보
- G1 GC는 4GB 이상 힙에서 최적이지만, 512MB에서도 Serial GC 대비 우수한 성능
